### PR TITLE
feat: Refactor to use MCP's low-level server

### DIFF
--- a/mcp_openapi/api_client.py
+++ b/mcp_openapi/api_client.py
@@ -1,60 +1,54 @@
-from typing import TypedDict
+from typing import Any
 from aiohttp import ClientSession
 import openapi_parser.specification as openapi_spec
 
 from http import HTTPMethod
 
-
-class RegisteredRequest(TypedDict):
-    method: HTTPMethod
-    path: str
-    op: openapi_spec.Operation
+import yarl
 
 
 class APIClient:
-    requests: dict[str, RegisteredRequest]
+    """
+    Handles the making of API requests based on an OpenAPI spec.
 
-    def __init__(self, base_url: str):
-        self.session = ClientSession(base_url=base_url)
-        self.requests = {}
+    TODO: Introduce authentication here.
 
-    def add_request(
-        self, name: str, method: HTTPMethod, path: str, op: openapi_spec.Operation
+    """
+
+    spec: openapi_spec.Specification
+    base_url: yarl.URL
+    session: ClientSession
+
+    def __init__(self, spec: openapi_spec.Specification, spec_url: str):
+        self.spec = spec
+
+        self.base_url = extract_base_url(spec, spec_url)
+        self.session = ClientSession(base_url=str(self.base_url))
+
+    async def call(
+        self,
+        method: HTTPMethod,
+        path: str,
+        query_params: dict[str, Any],
+        body: dict[str, Any],
     ):
-        self.requests[name] = {
-            "method": method,
-            "path": path,
-            "op": op,
-        }
-
-    async def call(self, name: str, **kwargs):
-        request = self.requests[name]
-
-        path_params = {}
-        query_params = {}
-        body_params = {}
-
-        for param in request["op"].parameters:
-            if param.name not in kwargs:
-                continue
-
-            if "{" + param.name + "}" in request["path"]:
-                path_params[param.name] = kwargs[param.name]
-            else:
-                query_params[param.name] = kwargs[param.name]
-
-            if param.name in kwargs:
-                path_params[param.name] = kwargs[param.name]
-
-        if request["op"].request_body:
-            for content in request["op"].request_body.content:
-                if isinstance(content.schema, openapi_spec.Object):
-                    for prop in content.schema.properties:
-                        body_params[prop.name] = kwargs[prop.name]
-
-        path = request["path"].format(**path_params)
-
         async with self.session.request(
-            request["method"].value, path, params=query_params, json=body_params
+            method, path, params=query_params, json=body
         ) as response:
             return await response.text()
+
+
+def extract_base_url(spec: openapi_spec.Specification, spec_url: str) -> yarl.URL:
+    # Get first server URL
+    # TODO: Allow this to be overridden by a CLI arg
+    if not spec.servers:
+        raise ValueError("No servers found in OpenAPI spec")
+
+    server_url = yarl.URL(spec.servers[0].url)
+    if not server_url.is_absolute():
+        # TODO: test this jank
+        # Base URL, if the spec server URL is relative
+        base_url = yarl.URL(spec_url)
+        server_url = base_url.join(server_url)
+
+    return server_url

--- a/mcp_openapi/api_client.py
+++ b/mcp_openapi/api_client.py
@@ -35,6 +35,7 @@ class APIClient:
         async with self.session.request(
             method, path, params=query_params, json=body
         ) as response:
+            # TODO: Provide some information about the response for non-2xx
             return await response.text()
 
 

--- a/mcp_openapi/cli.py
+++ b/mcp_openapi/cli.py
@@ -1,16 +1,21 @@
+import logging
 from typing import Annotated, TypedDict
 import typer
-
+from starlette.applications import Starlette
+from starlette.routing import Mount, Route
+from mcp.server.sse import SseServerTransport
+from mcp.server.stdio import stdio_server
+import uvicorn
 from mcp_openapi.async_typer import AsyncTyper
 from mcp_openapi.server import ServerFactory
-from mcp_openapi.settings import Settings as OpenAPISettings
-from mcp.server.fastmcp.server import Settings as FastMCPSettings
+from mcp_openapi.settings import LogLevel, Settings as OpenAPISettings
 
 
 app = AsyncTyper()
 
 
 class State(TypedDict):
+    settings: OpenAPISettings
     server_factory: ServerFactory
 
 
@@ -19,51 +24,79 @@ state: State | None = None
 
 @app.callback()
 def main(
-    openapi_url: Annotated[
-        str, typer.Option(help="The URL of the OpenAPI spec to serve")
-    ],
-    fastmcp_debug: Annotated[
-        bool, typer.Option(help="Enable debug mode for the MCP server")
-    ] = False,
-    fastmcp_log_level: Annotated[
-        str, typer.Option(help="The log level for the MCP server")
-    ] = "INFO",
-    fastmcp_sse_host: Annotated[
-        str, typer.Option(help="The host to serve the MCP server on")
-    ] = "0.0.0.0",
-    fastmcp_sse_port: Annotated[
-        int, typer.Option(help="The port to serve the MCP server on")
-    ] = 8000,
+    openapi_url: Annotated[str, typer.Option(help="URL of the OpenAPI spec to serve")],
+    log_level: Annotated[
+        LogLevel, typer.Option(help="Python log level")
+    ] = LogLevel.INFO,
 ):
-    openapi_settings: OpenAPISettings = OpenAPISettings.model_validate(
-        {"openapi_url": openapi_url}
+    settings: OpenAPISettings = OpenAPISettings.model_validate(
+        {"openapi_url": openapi_url, "log_level": log_level.value}
     )
-    fastmcp_settings: FastMCPSettings = FastMCPSettings.model_validate(
-        {
-            "debug": fastmcp_debug,
-            "log_level": fastmcp_log_level,
-            "host": fastmcp_sse_host,
-            "port": fastmcp_sse_port,
-        }
-    )
+
+    logging.basicConfig(level=log_level.value)
 
     global state
     state = {
-        "server_factory": ServerFactory(openapi_settings, fastmcp_settings),
+        "settings": settings,
+        "server_factory": ServerFactory(settings),
     }
 
 
 @app.command()
-async def sse():
-    assert state["server_factory"] is not None
+async def sse(
+    sse_host: Annotated[
+        str, typer.Option(help="The host to serve the MCP server on")
+    ] = "0.0.0.0",
+    sse_port: Annotated[
+        int, typer.Option(help="The port to serve the MCP server on")
+    ] = 8000,
+    debug: Annotated[
+        bool, typer.Option(help="Enable Starlette server debug mode")
+    ] = False,
+):
+    assert state is not None
 
-    server = await state["server_factory"].build_server()
-    await server.run_sse_async()
+    mcp_server = await state["server_factory"].build_server()
+
+    sse = SseServerTransport("/messages/")
+
+    async def handle_sse(request):
+        async with sse.connect_sse(
+            request.scope, request.receive, request._send
+        ) as streams:
+            await mcp_server.run(
+                streams[0],
+                streams[1],
+                mcp_server.create_initialization_options(),
+            )
+
+    starlette_app = Starlette(
+        debug=debug,
+        routes=[
+            Route("/sse", endpoint=handle_sse),
+            Mount("/messages/", app=sse.handle_post_message),
+        ],
+    )
+
+    config = uvicorn.Config(
+        starlette_app,
+        host=sse_host,
+        port=sse_port,
+        log_level=state["settings"].log_level.value,
+    )
+    server = uvicorn.Server(config)
+    await server.serve()
 
 
 @app.command()
 async def stdio():
-    assert state["server_factory"] is not None
+    assert state is not None
 
     server = await state["server_factory"].build_server()
-    await server.run_stdio_async()
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )

--- a/mcp_openapi/server.py
+++ b/mcp_openapi/server.py
@@ -1,33 +1,18 @@
-from http import HTTPMethod
-from typing import Annotated, Any
-from mcp.server.fastmcp.server import FastMCP, Settings as FastMCPSettings
-from mcp.server.fastmcp.tools.tool_manager import (
-    ToolManager,
-    logger as tool_manager_logger,
-)
-from mcp.server.fastmcp.tools.base import Tool
-from mcp.server.fastmcp.utilities.func_metadata import FuncMetadata, ArgModelBase
-from pydantic import Field, WithJsonSchema, create_model
-from pydantic.fields import FieldInfo
-from pydantic_core import PydanticUndefined
-import yarl
+from mcp.server.lowlevel import Server
+from mcp.types import CallToolRequest, ListToolsRequest
 
 from openapi_parser import parse as openapi_parser_parse
 import openapi_parser.specification as openapi_spec
 
-from mcp_openapi.api_client import APIClient
 from mcp_openapi.settings import Settings as OpenAPISettings
+from mcp_openapi.spec_handlers import OpenAPISpecHandler
 
 
 class ServerFactory:
     openapi_settings: OpenAPISettings
-    fastmcp_settings: FastMCPSettings
 
-    def __init__(
-        self, openapi_settings: OpenAPISettings, fastmcp_settings: FastMCPSettings
-    ):
+    def __init__(self, openapi_settings: OpenAPISettings):
         self.openapi_settings = openapi_settings
-        self.fastmcp_settings = fastmcp_settings
 
     async def load_openapi_spec(self) -> openapi_spec.Specification:
         """Load the OpenAPI spec from the URL - this should resolve any components in other specs as well"""
@@ -35,175 +20,25 @@ class ServerFactory:
             uri=str(self.openapi_settings.openapi_url), strict_enum=False
         )
 
-    async def build_server(self) -> FastMCP:
+    def extract_operations(
+        self, spec: openapi_spec.Specification
+    ) -> list[openapi_spec.Operation]:
+        """Extract the operations from the OpenAPI spec"""
+        return [op for path in spec.paths for op in path.operations]
+
+    async def build_server(self) -> Server:
         """Build the server from the OpenAPI spec"""
 
         spec = await self.load_openapi_spec()
+        spec_handler = OpenAPISpecHandler(spec, str(self.openapi_settings.openapi_url))
 
-        # Get first server URL
-        # TODO: Allow this to be overridden by a CLI arg
-        if not spec.servers:
-            raise ValueError("No servers found in OpenAPI spec")
-
-        server_url = yarl.URL(spec.servers[0].url)
-        if not server_url.is_absolute():
-            # TODO: test this jank
-            server_url = yarl.URL(str(self.openapi_settings.openapi_url)).join(
-                server_url
-            )
-
-        # Initialize API client
-        api_client = APIClient(str(server_url).rstrip("/"))
-
-        # Register each path operation as a tool
-        # TODO: Filter by tags
-        # TODO: Filter by operation_id matches
-        # TODO: Filter by HTTP method
-        # TODO: Restrict to specified subset of paths
-        mcp = FastMCP()
-        for path in spec.paths:
-            for op in path.operations:
-                tool = tool_from_path(api_client, path, op)
-                register_tool(mcp, tool)
-
-        return mcp
-
-
-def register_tool(server: FastMCP, tool: Tool) -> None:
-    tool_manager: ToolManager = server._tool_manager
-
-    # Duplicated code from ToolManager.add_tool, without the Tool.function introspector
-    # Perhaps we should go lower level than FastMCP, might make all the pydantic stuff redundant
-    existing = tool_manager._tools.get(tool.name)
-    if existing:
-        if tool_manager.warn_on_duplicate_tools:
-            tool_manager_logger.warning(f"Tool already exists: {tool.name}")
-            return
-
-    tool_manager._tools[tool.name] = tool
-
-
-def json_schema_type_to_python_type(
-    schema: openapi_spec.Schema,
-) -> type[int | str | bool | list[Any] | dict[str, Any] | None | float]:
-    """Convert a JSON Schema type to a Python type - likely incomplete"""
-
-    if schema.type == openapi_spec.DataType.INTEGER:
-        return int
-    if schema.type == openapi_spec.DataType.STRING:
-        return str
-    if schema.type == openapi_spec.DataType.BOOLEAN:
-        return bool
-    if schema.type == openapi_spec.DataType.ARRAY:
-        return list[Any]
-    if schema.type == openapi_spec.DataType.OBJECT:
-        return dict[str, Any]
-    if schema.type == openapi_spec.DataType.NUMBER:
-        return float
-    if schema.type == openapi_spec.DataType.NULL:
-        return type(None)
-
-    raise ValueError(f"Unsupported type: {schema.type}")
-
-
-def tool_params_from_operation(op: openapi_spec.Operation) -> FuncMetadata:
-    """
-    Collect the parameters required for the operation
-
-    This can include path parameters, query parameters, and body parameters.
-
-    TODO: Here be bugs for sure.
-
-    """
-
-    def create_param(
-        p: openapi_spec.Parameter | openapi_spec.Property,
-        is_required: bool | None = None,
-    ) -> tuple[type, FieldInfo]:
-        type_ = json_schema_type_to_python_type(p.schema)
-
-        if isinstance(p, openapi_spec.Parameter):
-            is_required = is_required if is_required is not None else p.required
-
-        annotation = Annotated[
-            type_,  # type: ignore[valid-type]  # This seems impossible to make mypy happy, hopefully we can remove it later
-            Field(),
-            WithJsonSchema(
-                {
-                    "title": p.name,
-                    "type": p.schema.type.value,
-                    "description": p.schema.description,
-                    "default": p.schema.default,
-                    "required": is_required,
-                    "enum": p.schema.enum,
-                    "examples": p.schema.example,
-                    "deprecated": p.schema.deprecated,
-                    "readOnly": p.schema.read_only,
-                    "writeOnly": p.schema.write_only,
-                }
-            ),
-        ]
-
-        default = p.schema.default if p.schema.default else PydanticUndefined
-
-        field_info = FieldInfo.from_annotated_attribute(
-            annotation,  # type: ignore[arg-type]
-            default,
+        server: Server = Server(
+            name=spec.info.title,
+            version=spec.info.version,
+            instructions=f"Use these tools to make API requests to the {spec.info.title} API.\nAPI description:\n{spec.info.description}",
         )
-        assert field_info.annotation is not None
-        return field_info.annotation, field_info
 
-    params = {}
+        server.request_handlers[CallToolRequest] = spec_handler.call_tool
+        server.request_handlers[ListToolsRequest] = spec_handler.list_tools
 
-    if op.parameters:
-        for p in op.parameters:
-            params[p.name] = create_param(p)
-
-    if rb := op.request_body:
-        for content in rb.content:
-            if isinstance(content.schema, openapi_spec.Object):
-                for prop in content.schema.properties:
-                    params[prop.name] = create_param(
-                        prop, is_required=prop.name in content.schema.required
-                    )
-
-    arg_model = create_model(
-        f"{op.operation_id}Arguments",
-        **params,
-        __base__=ArgModelBase,  # type: ignore[call-overload]
-    )
-
-    return FuncMetadata(
-        arg_model=arg_model,
-    )
-
-
-def tool_from_path(
-    api_client: APIClient, path: openapi_spec.Path, op: openapi_spec.Operation
-) -> Tool:
-    """Convert a path operation to a tool"""
-
-    async def fn(*args, **kwargs) -> str:
-        """The function that will be called when the tool is invoked"""
-        assert op.operation_id is not None
-        return await api_client.call(op.operation_id, *args, **kwargs)
-
-    # Register the operation with the API client, so it can match up parameters to path/query/body parameters
-    assert op.operation_id is not None
-    api_client.add_request(
-        op.operation_id, HTTPMethod(op.method.value.upper()), path.url, op
-    )
-
-    # Create the tool metadata
-    fn_metadata = tool_params_from_operation(op)
-
-    # Build the tool
-    return Tool(
-        fn=fn,
-        fn_metadata=fn_metadata,
-        name=op.operation_id,
-        description=" - ".join(filter(None, [op.summary, op.description])),
-        parameters=fn_metadata.arg_model.model_json_schema(),
-        is_async=True,
-        context_kwarg=None,
-    )
+        return server

--- a/mcp_openapi/settings.py
+++ b/mcp_openapi/settings.py
@@ -1,8 +1,20 @@
+from enum import Enum
 from pydantic_core import Url
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+import logging
+
+
+class LogLevel(Enum):
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    ERROR = logging.ERROR
+    CRITICAL = logging.CRITICAL
 
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="MCP_OPENAPI_")
 
     openapi_url: Url
+    log_level: LogLevel = LogLevel.INFO

--- a/mcp_openapi/spec_handlers.py
+++ b/mcp_openapi/spec_handlers.py
@@ -1,0 +1,192 @@
+from http import HTTPMethod
+import logging
+from mcp import Tool
+from mcp.types import TextContent
+from mcp.types import ServerResult, CallToolRequest, CallToolResult, ListToolsResult
+import openapi_parser.specification as openapi_spec
+
+from mcp_openapi.api_client import APIClient
+
+
+class OpenAPISpecHandler:
+    """
+    Handles the mapping of OpenAPI operations to MCP tools.
+
+    Provides two request handlers for an mcp.Server:
+
+    - list_tools: Returns a list of tools based on the OpenAPI spec.
+    - call_tool: Makes an API request using the operation and returns the result.
+
+    """
+
+    spec: openapi_spec.Specification
+    spec_url: str
+
+    operations: dict[str, tuple[openapi_spec.Path, openapi_spec.Operation]]
+
+    def __init__(self, spec: openapi_spec.Specification, spec_url: str):
+        self.spec = spec
+        self.spec_url = spec_url
+
+        self.operations = {}
+        for path in self.spec.paths:
+            for op in path.operations:
+                if op.operation_id is None:
+                    raise ValueError(f"Operation {op} has no operation_id")
+
+                self.operations[op.operation_id] = (path, op)
+
+        self.api_client = APIClient(self.spec, self.spec_url)
+
+        self.logger = logging.getLogger(__name__)
+
+    async def list_tools(self) -> ServerResult:
+        tools: list[Tool] = []
+
+        # Register each path operation as a tool
+        # TODO: Filter by tags
+        # TODO: Filter by operation_id matches
+        # TODO: Filter by HTTP method
+        # TODO: Restrict to specified subset of paths
+        for op_id, (path, op) in self.operations.items():
+            self.logger.debug(
+                f"Registering operation {op_id} as a tool ({op.method=} {path.url=})"
+            )
+
+            input_schema = {}
+            required_fields = []
+
+            # TODO: From 5 mins of searching, it seems like not every LLM supports nested
+            # objects in the input schema, so we will consolidate them until we figure out
+            # how widespread that is (OpenAPI certainly might not support it, as of mid-2024).
+
+            # Add path parameters to the input schema
+            for param in op.parameters:
+                if param.name in input_schema:
+                    raise ValueError(f"Duplicate parameter name: {param.name}")
+
+                self.logger.debug(
+                    f"Adding parameter {param.name} to tool {op_id} ({param.schema=} {param.required=})"
+                )
+
+                input_schema[param.name] = param.schema
+                if param.required:
+                    required_fields.append(param.name)
+
+            # Add request body parameters to the input schema
+            if op.request_body:
+                for content in op.request_body.content:
+                    schema = content.schema
+                    # TODO: Handle non-object bodies, e.g. images
+                    if isinstance(schema, openapi_spec.Object):
+                        for prop in schema.properties:
+                            if prop.name in input_schema:
+                                raise ValueError(
+                                    f"Duplicate parameter name: {prop.name}"
+                                )
+
+                            input_schema[prop.name] = prop.schema
+                            if prop.name in schema.required:
+                                required_fields.append(prop.name)
+
+            description = " - ".join(filter(None, [op.summary, op.description]))
+            self.logger.debug(
+                f"Adding tool {op_id}, {description=} {input_schema=} {required_fields=}"
+            )
+            tools.append(
+                Tool(
+                    name=op_id,
+                    description=description,
+                    inputSchema={
+                        "type": "object",
+                        "properties": input_schema,
+                        "required": required_fields,
+                    },
+                )
+            )
+
+        return ServerResult(ListToolsResult(tools=tools))
+
+    async def call_tool(self, request: CallToolRequest) -> ServerResult:
+        path, op = self.operations[request.params.name]
+
+        # TODO: The mixed-bag parameter names as described above also apply here.
+
+        # Build the path using parameters
+        url_path = path.url
+        for param in op.parameters:
+            if param.location == "path":
+                url_path = url_path.replace(
+                    "{" + param.name + "}", str(request.params.arguments[param.name])
+                )
+
+        # Map out the parameters from the request
+        query_params = self._extract_query_params(op, request)
+        body_params = self._extract_body_params(op, request)
+        all_params = list(query_params.keys()) + list(body_params.keys())
+
+        required_params = self._get_required_params(op, request)
+        if required_params - set(all_params):
+            raise ValueError(
+                f"Missing required parameters: {required_params - set(all_params)}"
+            )
+
+        # Call the API
+        result = await self.api_client.call(
+            HTTPMethod(op.method.value.upper()), url_path, query_params, body_params
+        )
+
+        return ServerResult(
+            CallToolResult(content=[TextContent(type="text", text=result)])
+        )
+
+    def _extract_query_params(
+        self, op: openapi_spec.Operation, request: CallToolRequest
+    ) -> dict[str, str]:
+        if not request.params.arguments:
+            return {}
+
+        query_params: dict[str, str] = {}
+        for param in op.parameters:
+            if param.location == "query":
+                query_params[param.name] = str(request.params.arguments[param.name])
+        return query_params
+
+    def _extract_body_params(
+        self, op: openapi_spec.Operation, request: CallToolRequest
+    ) -> dict[str, str]:
+        if not request.params.arguments or not op.request_body:
+            return {}
+
+        body_params: dict[str, str] = {}
+        for content in op.request_body.content:
+            schema = content.schema
+            # TODO: Handle non-object bodies, e.g. images
+            if isinstance(schema, openapi_spec.Object):
+                for prop in schema.properties:
+                    if prop.name not in request.params.arguments:
+                        raise ValueError(
+                            f"Missing required body parameter: {prop.name}"
+                        )
+
+                    body_params[prop.name] = str(request.params.arguments[prop.name])
+
+        return body_params
+
+    def _get_required_params(
+        self, op: openapi_spec.Operation, request: CallToolRequest
+    ) -> set[str]:
+        required_params: set[str] = set()
+        for param in op.parameters:
+            if param.required:
+                required_params.add(param.name)
+
+        if op.request_body:
+            for content in op.request_body.content:
+                schema = content.schema
+                if isinstance(schema, openapi_spec.Object):
+                    for prop in schema.properties:
+                        if prop.name in schema.required:
+                            required_params.add(prop.name)
+
+        return required_params

--- a/mcp_openapi/spec_handlers.py
+++ b/mcp_openapi/spec_handlers.py
@@ -41,6 +41,7 @@ class OpenAPISpecHandler:
         self.logger = logging.getLogger(__name__)
 
     async def list_tools(self) -> ServerResult:
+        # TODO: Do more of this at server startup, rather than at runtime
         tools: list[Tool] = []
 
         # Register each path operation as a tool
@@ -63,6 +64,7 @@ class OpenAPISpecHandler:
             # Add path parameters to the input schema
             for param in op.parameters:
                 if param.name in input_schema:
+                    # TODO: Log this, and validate on server startup
                     raise ValueError(f"Duplicate parameter name: {param.name}")
 
                 self.logger.debug(
@@ -127,6 +129,7 @@ class OpenAPISpecHandler:
 
         required_params = self._get_required_params(op, request)
         if required_params - set(all_params):
+            # TODO: Provide this as context to the LLM rather than erroring
             raise ValueError(
                 f"Missing required parameters: {required_params - set(all_params)}"
             )
@@ -165,6 +168,7 @@ class OpenAPISpecHandler:
             if isinstance(schema, openapi_spec.Object):
                 for prop in schema.properties:
                     if prop.name not in request.params.arguments:
+                        # TODO: Provide this as context to the LLM rather than erroring
                         raise ValueError(
                             f"Missing required body parameter: {prop.name}"
                         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,7 @@ dependencies = [
     "aiohttp>=3.11.12",
     "mcp[cli]>=1.3.0",
     "pydantic-settings>=2.8.0",
-    "pyyaml>=6.0.2",
     "typer>=0.15.1",
-    "fastapi>=0.115.8",
     "openapi3-parser>=1.1.19",
 ]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -475,11 +475,9 @@ version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
-    { name = "fastapi" },
     { name = "mcp", extra = ["cli"] },
     { name = "openapi3-parser" },
     { name = "pydantic-settings" },
-    { name = "pyyaml" },
     { name = "typer" },
 ]
 
@@ -495,11 +493,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.12" },
-    { name = "fastapi", specifier = ">=0.115.8" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.3.0" },
     { name = "openapi3-parser", specifier = ">=1.1.19" },
     { name = "pydantic-settings", specifier = ">=2.8.0" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "typer", specifier = ">=0.15.1" },
 ]
 


### PR DESCRIPTION
This allows us to remove lots of the logic used to bootstrap FastMCP's Tools, that was based on Tool.from_function.